### PR TITLE
Retrieve lat and lon from results without using hasproperty

### DIFF
--- a/src/plotting/plotting_utils.jl
+++ b/src/plotting/plotting_utils.jl
@@ -48,11 +48,11 @@ function plot_analysis_flow_parameters(simulation::SIM, A_values, n_values) wher
     
     
     Δx = hasproperty(result[1,1], :Δx) ? result[1,1].Δx : 0
-    
-    #Extract longitude and latitude 
-    lon = hasproperty(result[1,1], :lon) ? result[1,1].lon : "none"
-    lat = hasproperty(result[1,1], :lat) ? result[1,1].lat : "none"
-    
+
+    #Extract longitude and latitude
+    lon = result[1,1].lon
+    lat = result[1,1].lat
+
 
     ny, nx = size(h_diff[1,1])
     h_diff = [reverse(h_diff[i,j]', dims=2) for i in 1:rows, j in 1:cols]


### PR DESCRIPTION
Hi @facusapienza21 @JordiBolibar!
From what I understand, https://github.com/ODINN-SciML/Sleipnir.jl/issues/42 refers to [these lines](https://github.com/vivekag7/Huginn.jl/blob/8a922b5ef5d6aeb487074fcd74429b28510b698d/src/plotting/plotting_utils.jl#L59-L60).
I tried to remove the `hasproperty` conditions and it turns out that all the tests are passing. I guess this was a side effect of PyCall.

This PR is associated to https://github.com/ODINN-SciML/Sleipnir.jl/pull/80