### PR TITLE
Make structs of concrete type

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Huginn"
 uuid = "9cb796e9-d0ea-421b-b37d-eb97bc1add55"
 authors = ["Jordi Bolibar <jordi.bolibar@gmail.com>", "Facundo Sapienza <sapienza@stanford.edu>", "Alban Gossard <alban.paul.gossard@gmail.com>", "Mathieu Le Séac'h"]
-version = "0.14.0"
+version = "0.14.1"
 
 [deps]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
@@ -51,7 +51,7 @@ ProgressMeter = "1"
 Random = "1.10, 1.11"
 Reexport = "1"
 Revise = "3"
-Sleipnir = "0.14"
+Sleipnir = "0.14.1"
 Statistics = "1"
 Test = "1.10, 1.11"
 Tullio = "0.3"

--- a/src/parameters/SolverParameters.jl
+++ b/src/parameters/SolverParameters.jl
@@ -143,7 +143,9 @@ function Parameters(;
 )
 
     # Build the parameters based on all the subtypes of parameters
-    parameters = Sleipnir.Parameters(physical, simulation,
+    parameters = Sleipnir.Parameters{
+        typeof(physical), typeof(simulation), Nothing, typeof(solver), Nothing}(
+        physical, simulation,
         nothing, solver, nothing)
 
     enable_multiprocessing(parameters)

--- a/src/simulations/predictions/Prediction.jl
+++ b/src/simulations/predictions/Prediction.jl
@@ -61,43 +61,38 @@ end
 # Display setup
 Base.show(io::IO, ::MIME"text/plain", prediction::Prediction) = Base.show(io, prediction)
 function Base.show(io::IO, prediction::Prediction)
-    label(s) = printstyled(io, rpad(s, 14); color = 183)
-    sep() = printstyled(io, " · "; color = :light_black)
-    field(s) = printstyled(io, s; color = :light_black)
-    val(s) = print(io, s)
-    hint(s) = printstyled(io, s; color = :light_black)
-    check(b) = b ? "\e[32m✓\e[0m " : "\e[31m✗\e[0m "
+    pad = 14
 
     println(io, "Prediction")
 
     # glaciers
-    label("  glaciers")
+    label(io, "  glaciers", pad)
     n = length(prediction.glaciers)
-    val("$n");
-    hint(" $(n == 1 ? "glacier" : "glaciers")")
+    val(io, "$n");
+    hint(io, " $(n == 1 ? "glacier" : "glaciers")")
     println(io)
 
     # model
-    label("  model")
-    field("iceflow");
+    label(io, "  model", pad)
+    field(io, "iceflow");
     print(io, " = ")
-    val("$(nameof(typeof(prediction.model.iceflow)))")
-    sep()
-    field("mass_balance");
+    val(io, "$(nameof(typeof(prediction.model.iceflow)))")
+    sep(io)
+    field(io, "mass_balance");
     print(io, " = ")
-    val("$(nameof(typeof(prediction.model.mass_balance)))")
-    sep()
-    field("learnable");
+    val(io, "$(nameof(typeof(prediction.model.mass_balance)))")
+    sep(io)
+    field(io, "learnable");
     print(io, " = ")
     if isnothing(prediction.model.trainable_components)
-        hint("(nothing)")
+        hint(io, "(nothing)")
     else
         Base.show(io, prediction.model.trainable_components)
     end
     println(io)
 
     # parameters
-    label("  parameters")
+    label(io, "  parameters", pad)
     println(io)
     # Capture the Parameters show output and re-indent each line
     params_str = sprint(show, prediction.parameters)
@@ -110,24 +105,24 @@ function Base.show(io::IO, prediction::Prediction)
     end
 
     # cache
-    label("  cache")
+    label(io, "  cache", pad)
     if isnothing(prediction.cache)
-        hint("(nothing)")
+        hint(io, "(nothing)")
     else
-        val("$(nameof(typeof(prediction.cache)))")
+        val(io, "$(nameof(typeof(prediction.cache)))")
     end
     println(io)
 
     # results
-    label("  results")
+    label(io, "  results", pad)
     n_results = length(prediction.results)
     if n_results == 0
         print(io, check(false));
-        hint(" not yet run")
+        hint(io, " not yet run")
     else
         print(io, check(true));
-        val(" $n_results")
-        hint(" $(n_results == 1 ? "result" : "results") ready")
+        val(io, " $n_results")
+        hint(io, " $(n_results == 1 ? "result" : "results") ready")
     end
     println(io)
 end

--- a/src/simulations/predictions/Prediction.jl
+++ b/src/simulations/predictions/Prediction.jl
@@ -13,12 +13,18 @@ A mutable struct that represents a prediction simulation.
   - `parameters::Sleipnir.Parameters`: The parameters used for the prediction.
   - `results::Vector{Results}`: A vector of results obtained from the prediction.
 """
-mutable struct Prediction{CACHE} <: Simulation
-    model::Sleipnir.Model
+mutable struct Prediction{
+    MODEL <: Sleipnir.Model,
+    CACHE,
+    GLACIER <: Sleipnir.AbstractGlacier,
+    PARAMS <: Sleipnir.Parameters,
+    RES <: Vector{Results}
+} <: Simulation
+    model::MODEL
     cache::Union{CACHE, Nothing}
-    glaciers::Vector{Sleipnir.AbstractGlacier}
-    parameters::Sleipnir.Parameters
-    results::Vector{Results}
+    glaciers::Vector{GLACIER}
+    parameters::PARAMS
+    results::RES
 
     function Prediction(
             model::Sleipnir.Model,
@@ -26,7 +32,9 @@ mutable struct Prediction{CACHE} <: Simulation
             parameters::Sleipnir.Parameters,
             results::Vector{Results}
     )
-        return new{cache_type(model)}(model, nothing, glaciers, parameters, results)
+        return new{typeof(model), cache_type(model), eltype(glaciers),
+            typeof(parameters), typeof(results)}(
+            model, nothing, glaciers, parameters, results)
     end
 end
 

--- a/test/PDE_solve.jl
+++ b/test/PDE_solve.jl
@@ -4,7 +4,6 @@ function pde_solve_test(;
         atol::F,
         save_refs::Bool = false,
         MB::Bool = false,
-        fast::Bool = true,
         laws_A = nothing,
         laws_C = nothing,
         callback_laws = false

--- a/test/PDE_solve.jl
+++ b/test/PDE_solve.jl
@@ -6,7 +6,8 @@ function pde_solve_test(;
         MB::Bool = false,
         laws_A = nothing,
         laws_C = nothing,
-        callback_laws = false
+        callback_laws = false,
+        save_plot::Bool = false
 ) where {F <: AbstractFloat}
     println("PDE solving with MB = $MB, laws_A = $laws_A, laws_C = $laws_C, callback_laws = $callback_laws")
 
@@ -31,24 +32,9 @@ function pde_solve_test(;
             step = 2.0 # Large step to store few data
         )
     )
-    JET.@test_opt target_modules=(Sleipnir, Muninn, Huginn) Parameters(
-        simulation = SimulationParameters(
-            use_MB = MB,
-            use_velocities = false,
-            tspan = (2010.0, 2015.0),
-            working_dir = Huginn.root_dir,
-            test_mode = true,
-            rgi_paths = rgi_paths
-        ),
-        solver = SolverParameters(
-            reltol = 1e-12,
-            step = 2.0 # Large step to store few data
-        )
-    )
 
     # We retrieve some glaciers for the simulation
     glaciers = initialize_glaciers(rgi_ids, params)
-    # JET.@test_opt broken=true target_modules=(Sleipnir,Muninn,Huginn) initialize_glaciers(rgi_ids, params) # For the moment this is not type stable because of the readings (type of CSV files and RasterStack cannot be determined at compilation time)
 
     mass_balance = isnothing(MB) ? nothing : TImodel1(params)
 
@@ -93,21 +79,19 @@ function pde_solve_test(;
     end
 
     iceflow = SIA2Dmodel(params; A = A_law, C = C_law)
-    JET.@test_opt SIA2Dmodel(params; A = A_law, C = C_law)
-
     model = Model(; iceflow, mass_balance)
-    JET.@test_opt Model(; iceflow, mass_balance)
 
     # We create an ODINN prediction
     prediction = Prediction(model, glaciers, params)
 
-    JET.@test_opt target_modules=(Sleipnir, Muninn, Huginn) Prediction(model, glaciers, params)
-
     # We run the simulation
     @time run!(prediction)
 
-    # Test below is not ready yet
-    JET.@test_opt broken=true target_modules=(Sleipnir, Muninn, Huginn) Huginn.batch_iceflow_PDE!(1, prediction) # Call only the core of run! because saving to JLD2 file is not type stable and GC interferes with JET
+    if !MB && isnothing(laws_A) && isnothing(laws_C) # Test this only once
+        # Test below is not ready yet
+        JET.@test_opt broken=true target_modules=(Sleipnir, Muninn, Huginn) Huginn.batch_iceflow_PDE!(
+            1, prediction) # Call only the core of run! because saving to JLD2 file is not type stable and GC interferes with JET
+    end
 
     file_name = @match (MB, laws_A, laws_C, callback_laws) begin
         (false, nothing, nothing, false) => "PDE_refs_noMB"
@@ -151,9 +135,12 @@ function pde_solve_test(;
                 MB ? vtol = 30.0*atol : vtol = 12.0*atol # a little extra tolerance for surface velocities
 
                 ### PDE ###
-                plot_test_error(result, test_ref, "H", result.rgi_id, atol, MB)
-                plot_test_error(result, test_ref, "Vx", result.rgi_id, vtol, MB)
-                plot_test_error(result, test_ref, "Vy", result.rgi_id, vtol, MB)
+                if save_plot
+                    # This is only for debugging
+                    plot_test_error(result, test_ref, "H", result.rgi_id, atol, MB)
+                    plot_test_error(result, test_ref, "Vx", result.rgi_id, vtol, MB)
+                    plot_test_error(result, test_ref, "Vy", result.rgi_id, vtol, MB)
+                end
 
                 # Test that the PDE simulations are correct
                 mask = test_ref.H[end] .> 0.0

--- a/test/params_construction.jl
+++ b/test/params_construction.jl
@@ -18,6 +18,8 @@ function params_constructor_specified(save_refs::Bool = false)
         progress = true,
         progress_steps = 10
     )
+    @test check_concrete_types(solver_params; show = false)
+    @test check_field_types(typeof(solver_params); show = false)
 
     # Test prints
     println(solver_params)
@@ -34,6 +36,8 @@ end
 function params_constructor_default(save_refs::Bool = false)
     solver_params = SolverParameters()
     JET.@test_opt SolverParameters()
+    @test check_concrete_types(solver_params; show = false)
+    @test check_field_types(typeof(solver_params); show = false)
 
     if save_refs
         jldsave(joinpath(Huginn.root_dir, "test/data/params/solver_params_default.jld2"); solver_params)

--- a/test/prediction.jl
+++ b/test/prediction.jl
@@ -1,0 +1,40 @@
+function test_prediction()
+    rgi_ids = ["RGI60-11.03638", "RGI60-11.01450"]
+
+    rgi_paths = get_rgi_paths()
+    # Filter out glaciers that are not used to avoid having references that depend on all the glaciers processed in Gungnir
+    rgi_paths = Dict(k => rgi_paths[k] for k in rgi_ids)
+
+    params = Parameters(
+        simulation = SimulationParameters(
+            use_MB = true,
+            use_velocities = false,
+            tspan = (2010.0, 2015.0),
+            working_dir = Huginn.root_dir,
+            test_mode = true,
+            rgi_paths = rgi_paths
+        ),
+        solver = SolverParameters(reltol = 1e-8)
+    )
+    model = Model(iceflow = SIA2Dmodel(params), mass_balance = TImodel1(params))
+    JET.@test_opt Model(iceflow = SIA2Dmodel(params), mass_balance = TImodel1(params))
+    @test check_concrete_types(model; show = false)
+    @test check_field_types(typeof(model); show = false)
+
+    glacier_idx = 1
+
+    glaciers = initialize_glaciers(rgi_ids, params)
+    JET.@test_opt target_modules=(Sleipnir, Muninn, Huginn) initialize_glaciers(rgi_ids, params)[1]
+    @test check_concrete_types(glaciers; show = false)
+    @test check_field_types(typeof(glaciers); show = false)
+
+    simulation = Prediction(model, glaciers, params)
+    JET.@test_opt target_modules=(Sleipnir, Muninn, Huginn) Prediction(model, glaciers, params)
+    @test check_concrete_types(simulation; show = false)
+    @test_broken check_field_types(typeof(simulation); show = false)
+
+    cache = init_cache(model, simulation, glacier_idx, nothing)
+    JET.@test_opt init_cache(model, simulation, glacier_idx, nothing)
+    @test check_concrete_types(cache; show = false)
+    @test_broken check_field_types(typeof(cache); show = false)
+end

--- a/test/prediction.jl
+++ b/test/prediction.jl
@@ -1,4 +1,4 @@
-function test_prediction()
+function test_prediction_instantiation()
     rgi_ids = ["RGI60-11.03638", "RGI60-11.01450"]
 
     rgi_paths = get_rgi_paths()
@@ -16,17 +16,36 @@ function test_prediction()
         ),
         solver = SolverParameters(reltol = 1e-8)
     )
-    model = Model(iceflow = SIA2Dmodel(params), mass_balance = TImodel1(params))
-    JET.@test_opt Model(iceflow = SIA2Dmodel(params), mass_balance = TImodel1(params))
+    JET.@test_opt target_modules=(Sleipnir, Muninn, Huginn) Parameters(
+        simulation = SimulationParameters(
+            use_MB = true,
+            use_velocities = false,
+            tspan = (2010.0, 2015.0),
+            working_dir = Huginn.root_dir,
+            test_mode = true,
+            rgi_paths = rgi_paths
+        ),
+        solver = SolverParameters(reltol = 1e-8)
+    )
+    @test check_concrete_types(params; show = false)
+    @test check_field_types(typeof(params); show = false)
+
+    iceflow = SIA2Dmodel(params)
+    JET.@test_opt SIA2Dmodel(params)
+    @test check_concrete_types(iceflow; show = false)
+    @test check_field_types(typeof(iceflow); show = false)
+
+    model = Model(iceflow = iceflow, mass_balance = TImodel1(params))
+    JET.@test_opt Model(iceflow = iceflow, mass_balance = TImodel1(params))
     @test check_concrete_types(model; show = false)
     @test check_field_types(typeof(model); show = false)
-
-    glacier_idx = 1
 
     glaciers = initialize_glaciers(rgi_ids, params)
     JET.@test_opt target_modules=(Sleipnir, Muninn, Huginn) initialize_glaciers(rgi_ids, params)[1]
     @test check_concrete_types(glaciers; show = false)
     @test check_field_types(typeof(glaciers); show = false)
+
+    glacier_idx = 1
 
     simulation = Prediction(model, glaciers, params)
     JET.@test_opt target_modules=(Sleipnir, Muninn, Huginn) Prediction(model, glaciers, params)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -47,6 +47,7 @@ using Aqua
 include("utils_test.jl")
 include("params_construction.jl")
 include("halfar.jl")
+include("prediction.jl")
 include("PDE_solve.jl")
 include("mass_conservation.jl")
 include("laws.jl")
@@ -62,27 +63,27 @@ ENV["GKSwstype"]="nul"
     if GROUP == "All" || GROUP == "Core1"
         @testset "PDE solving integration tests" begin
             @testset "w/o MB w/o laws" pde_solve_test(;
-                rtol = 0.01, atol = 0.01, MB = false, fast = true)
+                rtol = 0.01, atol = 0.01, MB = false)
             @testset "w/  MB w/o laws" pde_solve_test(;
-                rtol = 0.01, atol = 0.01, MB = true, fast = true)
+                rtol = 0.01, atol = 0.01, MB = true)
             @testset "w/  MB w/  A scalar laws" pde_solve_test(;
                 rtol = 0.01, atol = 0.01, MB = true,
-                fast = true, laws_A = :scalar, callback_laws = false)
+                laws_A = :scalar, callback_laws = false)
             @testset "w/  MB w/  A scalar callback laws" pde_solve_test(;
                 rtol = 0.01, atol = 0.01, MB = true,
-                fast = true, laws_A = :scalar, callback_laws = true)
+                laws_A = :scalar, callback_laws = true)
             @testset "w/  MB w/  A matrix  laws" pde_solve_test(;
                 rtol = 0.01, atol = 0.01, MB = true,
-                fast = true, laws_A = :matrix, callback_laws = false)
+                laws_A = :matrix, callback_laws = false)
             @testset "w/  MB w/  A matrix callback laws" pde_solve_test(;
                 rtol = 0.01, atol = 0.01, MB = true,
-                fast = true, laws_A = :matrix, callback_laws = true)
+                laws_A = :matrix, callback_laws = true)
             @testset "w/  MB w/  C scalar laws" pde_solve_test(;
                 rtol = 0.01, atol = 0.01, MB = true,
-                fast = true, laws_C = :scalar, callback_laws = false)
+                laws_C = :scalar, callback_laws = false)
             @testset "w/  MB w/  C scallar callback laws" pde_solve_test(;
                 rtol = 0.01, atol = 0.01, MB = true,
-                fast = true, laws_C = :scalar, callback_laws = true)
+                laws_C = :scalar, callback_laws = true)
         end
     end
 
@@ -93,6 +94,7 @@ ENV["GKSwstype"]="nul"
     end
 
     if GROUP == "All" || GROUP == "Core3"
+        @testset "Prediction instantiation" test_prediction()
         @testset "Run TI models in-place" TI_run_test!(false; rtol = 1e-5, atol = 1e-5)
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -94,7 +94,7 @@ ENV["GKSwstype"]="nul"
     end
 
     if GROUP == "All" || GROUP == "Core3"
-        @testset "Prediction instantiation" test_prediction()
+        @testset "Prediction instantiation" test_prediction_instantiation()
         @testset "Run TI models in-place" TI_run_test!(false; rtol = 1e-5, atol = 1e-5)
     end
 


### PR DESCRIPTION
This PR makes `Prediction` and some of the parameter structs of concrete type by using parametric types. We couldn't make `HyperParameters` of concrete type since we overwrite its fields and their associated types when we use multiple optimizers.
This PR also simplifies the tests to speed them up.